### PR TITLE
fix all getLogger argument. Add empty bean fix to application.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
@@ -102,11 +106,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>42.2.23</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/revature/RevAssure/SecurityConfig.java
+++ b/src/main/java/com/revature/RevAssure/SecurityConfig.java
@@ -2,10 +2,9 @@ package com.revature.RevAssure;
 
 import com.revature.RevAssure.filters.JwtRequestFilter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,8 +15,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 
 /**
  * SPRING SECURITY

--- a/src/main/java/com/revature/RevAssure/controller/CurriculumController.java
+++ b/src/main/java/com/revature/RevAssure/controller/CurriculumController.java
@@ -7,7 +7,6 @@ import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.service.CurriculumService;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/curriculum")
 public class CurriculumController {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(CurriculumController.class);
 
     @Autowired
     private final CurriculumService curriculumService;

--- a/src/main/java/com/revature/RevAssure/controller/EventController.java
+++ b/src/main/java/com/revature/RevAssure/controller/EventController.java
@@ -7,7 +7,6 @@ import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.service.EventService;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/event")
 public class EventController {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(EventController.class);
 
     @Autowired
     private final EventService eventService;

--- a/src/main/java/com/revature/RevAssure/controller/ModuleController.java
+++ b/src/main/java/com/revature/RevAssure/controller/ModuleController.java
@@ -7,7 +7,6 @@ import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.service.ModuleService;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/module")
 public class ModuleController {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(ModuleController.class);
 
     @Autowired
     private ModuleService moduleService;

--- a/src/main/java/com/revature/RevAssure/controller/RevUserController.java
+++ b/src/main/java/com/revature/RevAssure/controller/RevUserController.java
@@ -4,7 +4,6 @@ import com.revature.RevAssure.dto.AuthenticationRequest;
 import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/revuser")
 public class RevUserController {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(RevUserController.class);
 
     @Autowired
     private final RevUserService revUserService;

--- a/src/main/java/com/revature/RevAssure/controller/TechnologyCategoryController.java
+++ b/src/main/java/com/revature/RevAssure/controller/TechnologyCategoryController.java
@@ -7,7 +7,6 @@ import com.revature.RevAssure.model.TechnologyCategory;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.service.TechnologyCategoryService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/technology_category")
 public class TechnologyCategoryController {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(TechnologyCategoryController.class);
 
     private TechnologyCategoryService technologyCategoryService;
     private RevUserService revUserService;

--- a/src/main/java/com/revature/RevAssure/controller/TopicController.java
+++ b/src/main/java/com/revature/RevAssure/controller/TopicController.java
@@ -8,7 +8,6 @@ import com.revature.RevAssure.model.Topic;
 import com.revature.RevAssure.service.RevUserService;
 import com.revature.RevAssure.service.TopicService;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/topic")
 public class TopicController{
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(TopicController.class);
 
     private final TopicService topicService;
     private final RevUserService revUserService;

--- a/src/main/java/com/revature/RevAssure/service/CurriculumService.java
+++ b/src/main/java/com/revature/RevAssure/service/CurriculumService.java
@@ -9,12 +9,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import org.postgresql.core.ConnectionFactory;
 
 @Service
 public class CurriculumService
 {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(CurriculumService.class);
     private CurriculumRepository curriculumRepository;
 
     @Autowired

--- a/src/main/java/com/revature/RevAssure/service/EventService.java
+++ b/src/main/java/com/revature/RevAssure/service/EventService.java
@@ -2,7 +2,6 @@ package com.revature.RevAssure.service;
 
 import com.revature.RevAssure.model.Event;
 import com.revature.RevAssure.repository.EventRepository;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +12,7 @@ import java.util.List;
 @Service
 public class EventService {
 
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(EventService.class);
     private EventRepository eventRepository;
 
     @Autowired

--- a/src/main/java/com/revature/RevAssure/service/ModuleService.java
+++ b/src/main/java/com/revature/RevAssure/service/ModuleService.java
@@ -2,7 +2,6 @@ package com.revature.RevAssure.service;
 
 import com.revature.RevAssure.model.Module;
 import com.revature.RevAssure.repository.ModuleRepository;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +12,7 @@ import java.util.List;
 @Service
 public class ModuleService {
 
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(ModuleService.class);
     /**
      * Repository Layer for Modules
      */

--- a/src/main/java/com/revature/RevAssure/service/RevUserDetailsService.java
+++ b/src/main/java/com/revature/RevAssure/service/RevUserDetailsService.java
@@ -2,7 +2,6 @@ package com.revature.RevAssure.service;
 
 import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.repository.RevUserRepository;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,7 @@ import java.util.ArrayList;
  */
 @Service
 public class RevUserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(RevUserDetailsService.class);
     /**
      * Repository layer for RevUser object
      */
@@ -46,7 +45,6 @@ public class RevUserDetailsService implements org.springframework.security.core.
         RevUser revUser = revUserRepository.findByUsername(s).orElseThrow(RuntimeException::new);
         String username = revUser.getUsername();
         String password = revUser.getPassword();
-        log.warn("Might throw UsernameNotFoundException");
         return new User(username, password, new ArrayList<>()); // ArrayList because we aren't dealing with Authorities
     }
 

--- a/src/main/java/com/revature/RevAssure/service/RevUserService.java
+++ b/src/main/java/com/revature/RevAssure/service/RevUserService.java
@@ -5,7 +5,6 @@ import com.revature.RevAssure.dto.AuthenticationResponse;
 import com.revature.RevAssure.model.RevUser;
 import com.revature.RevAssure.repository.RevUserRepository;
 import com.revature.RevAssure.util.JwtUtil;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class RevUserService {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(RevUserService.class);
 
     private final RevUserRepository revUserRepository;
 

--- a/src/main/java/com/revature/RevAssure/service/TechnologyCategoryService.java
+++ b/src/main/java/com/revature/RevAssure/service/TechnologyCategoryService.java
@@ -2,7 +2,6 @@ package com.revature.RevAssure.service;
 
 import com.revature.RevAssure.model.TechnologyCategory;
 import com.revature.RevAssure.repository.TechnologyCategoryRepository;
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,7 @@ import java.util.List;
  */
 @Service
 public class TechnologyCategoryService {
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(TechnologyCategoryService.class);
 
     private final TechnologyCategoryRepository techCatRepo;
 

--- a/src/main/java/com/revature/RevAssure/service/TopicService.java
+++ b/src/main/java/com/revature/RevAssure/service/TopicService.java
@@ -6,7 +6,6 @@ import com.revature.RevAssure.repository.TopicRepository;
 
 import java.util.List;
 
-import org.postgresql.core.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class TopicService {
     private final TopicRepository topicRepository;
-    private static final Logger log = LoggerFactory.getLogger(ConnectionFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(TopicService.class);
 
     @Autowired
     public TopicService(TopicRepository topicRepository){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,5 @@ management.endpoint.logfile.external_file=logs/app.log
 #Logging Settings
 logging.file.name=logs/app.log
 
+spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
+


### PR DESCRIPTION
This has the line in application.properties to quickly overcome the empty bean exception `spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false`
as well as cleaning up the POM (no more postgres dependency), and fixing all the get loggers that were taking posgres.core.connectionfactory as an input